### PR TITLE
Add DFE nuget feed

### DIFF
--- a/default.json
+++ b/default.json
@@ -33,7 +33,8 @@
   "nuget": {
     "token": "${{ secrets.RENOVATE_NUGET_TOKEN }}",
     "registryUrls": [
-      "https://nuget.pkg.github.com/DFE-Digital/index.json"
+      "https://api.nuget.org/v3/index.json", // The default NuGet.org feed
+      "https://nuget.pkg.github.com/DFE-Digital/index.json" // DFE GitHub Packages feed
     ]
   }
 }

--- a/default.json
+++ b/default.json
@@ -30,4 +30,10 @@
   "major": {
     "addLabels": ["major"]
   }
+  "nuget": {
+    "token": "${{ secrets.RENOVATE_NUGET_TOKEN }}",
+    "registryUrls": [
+      "https://nuget.pkg.github.com/DFE-Digital/index.json"
+    ]
+  }
 }

--- a/default.json
+++ b/default.json
@@ -33,8 +33,8 @@
   "nuget": {
     "token": "${{ secrets.RENOVATE_NUGET_TOKEN }}",
     "registryUrls": [
-      "https://api.nuget.org/v3/index.json", // The default NuGet.org feed
-      "https://nuget.pkg.github.com/DFE-Digital/index.json" // DFE GitHub Packages feed
+      "https://api.nuget.org/v3/index.json",
+      "https://nuget.pkg.github.com/DFE-Digital/index.json" 
     ]
   }
 }


### PR DESCRIPTION
Adds the private nuget registry to the default renovate config

This will require the organisation secret to be set as part of RITM0623436