### PR TITLE
Match exact package name for testing

### DIFF
--- a/default.json
+++ b/default.json
@@ -20,7 +20,8 @@
       "allowedVersions": "<=7.0.0"
     },
     {
-      "matchPackageNames": ["DfE.CoreLibs.*"],
+      "matchDepTypes": ["dependencies", "devDependencies"],
+      "matchPackageNames": ["DfE.CoreLibs.Testing"],
       "nuget": {
         "token": "${{secrets.RENOVATE_NUGET_TOKEN}}",
         "registryUrls": [


### PR DESCRIPTION
Renovate logs are showing that it is not picking up the correct URL.

```
DEBUG: GET https://api.nuget.org/v3/registration5-gz-semver2/dfe.corelibs.testing/index.json = (code=ERR_NON_2XX_3XX_RESPONSE, statusCode=404 retryCount=0, duration=199)
DEBUG: Datasource 404
{
  "datasource": "nuget"
  "packageName": "DfE.CoreLibs.Testing"
  "url": "https://api.nuget.org/v3/registration5-gz-semver2/dfe.corelibs.testing/index.json"
}

DEBUG: Failed to look up nuget package DfE.CoreLibs.Testing
{
  "dependency": "DfE.CoreLibs.Testing"
  "packageFile": "Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.Tests/Dfe.ManageFreeSchoolProjects.Tests.csproj"
}
```

So hoping this explicit rule can help me troubleshoot