### PR TITLE
Revert nuget package rules

### DIFF
--- a/default.json
+++ b/default.json
@@ -18,16 +18,6 @@
     {
       "matchPackageNames": [ "FluentAssertions" ],
       "allowedVersions": "<=7.0.0"
-    },
-    {
-      "matchDepTypes": ["dependencies", "devDependencies"],
-      "matchPackageNames": ["DfE.CoreLibs.Testing"],
-      "nuget": {
-        "token": "${{ secrets.repository.RENOVATE_NUGET_TOKEN }}",
-        "registryUrls": [
-          "https://nuget.pkg.github.com/DFE-Digital/index.json"
-        ]
-      }
     }
   ],
   "timezone": "Europe/London",


### PR DESCRIPTION
If your project has lockfile(s), for example a package.lock.json file, then you must set alternate feed settings in the NuGet.config file only. registryUrls set in other files are not passed to the NuGet commands. - Renovate docs