### PR TITLE
Use `config:best-practices` setting

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
+    "config:best-practices",
     "group:linters",
     "group:test",
     "schedule:weekly",


### PR DESCRIPTION
`config:base` became `config:recommended` some time ago: https://github.com/renovatebot/renovate/commit/f9e3e80e0c9c6a972d847f8740de5016a2bf698a. It looks like Renovate automatically translates the old name to the new one:

https://github.com/renovatebot/renovate/blob/f9e3e80e0c9c6a972d847f8740de5016a2bf698a/lib/config/presets/common.ts#L17

`config:best-practices` extends `config:recommended` as well as pinning Docker digests and keeping Renovate config up to date (e.g. changes in config naming as mentioned above). This all seems good an reasonable